### PR TITLE
Implement optimized wildcard request dispatching

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -886,9 +886,7 @@ impl SyncClient {
             }
 
             let (tx, rx) = mpsc::channel(1);
-            client
-                .request_inbox_mapping
-                .insert(reply_to.clone(), tx);
+            client.request_inbox_mapping.insert(reply_to.clone(), tx);
             client
                 .publish_with_reply(subject, &reply_to, payload)
                 .await?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@
 //!     let message = subscription.next().await.unwrap();
 //!     let message = String::from_utf8(message.into_payload()).unwrap();
 //!     println!("Received '{}'", message);
-//!     
+//!
 //!     // Disconnect from the server
 //!     client.disconnect().await;
 //! };
@@ -62,7 +62,7 @@ use futures::{
     lock::{Mutex, MutexGuard},
     stream::StreamExt,
 };
-use log::{debug, error, info, trace};
+use log::{debug, error, info, trace, warn};
 use owning_ref::{OwningRef, OwningRefMut};
 use pin_utils::pin_mut;
 use rand;
@@ -97,7 +97,9 @@ use crate::{
     },
 };
 
-pub use tokio::sync::{mpsc::Receiver as MpscReceiver, watch::Receiver as WatchReceiver};
+pub use tokio::sync::{
+    mpsc::Receiver as MpscReceiver, mpsc::Sender as MpscSender, watch::Receiver as WatchReceiver,
+};
 
 pub use crate::types::{
     error, Address, Authorization, ClientRef, ClientRefMut, ClientState, Connect, Info, Msg,
@@ -514,6 +516,9 @@ struct SyncClient {
     tcp_connect_timeout: Duration,
     delay_generator: DelayGenerator,
     subscriptions: HashMap<Sid, Subscription>,
+    request_inbox_mapping: HashMap<String, MpscSender<Msg>>,
+    request_wildcard_subscription: Option<Sid>,
+    request_base_inbox: String,
 }
 
 impl SyncClient {
@@ -549,6 +554,9 @@ impl SyncClient {
                 util::DEFAULT_COOL_DOWN,
             ),
             subscriptions: HashMap::new(),
+            request_inbox_mapping: HashMap::new(),
+            request_wildcard_subscription: None,
+            request_base_inbox: Uuid::new_v4().to_simple().to_string(),
         }
     }
 
@@ -827,23 +835,93 @@ impl SyncClient {
         }
     }
 
+    async fn request_wildcard_handler(
+        wrapped_client: Arc<Mutex<Self>>,
+        mut subscription_rx: MpscReceiver<Msg>,
+    ) {
+        let disconnecting = Self::disconnecting(Arc::clone(&wrapped_client));
+        pin_mut!(disconnecting);
+        loop {
+            // Select between the next message and disconnecting
+            let msg = match future::select(subscription_rx.next(), disconnecting).await {
+                Either::Left((Some(msg), unresolved_disconnecting)) => {
+                    disconnecting = unresolved_disconnecting;
+                    msg
+                }
+                Either::Left((None, _)) => break,
+                Either::Right(((), _)) => break,
+            };
+
+            let mut client = wrapped_client.lock().await;
+            let response_inbox = msg.subject().to_string();
+            if let Some(mut requester_tx) = client.request_inbox_mapping.remove(&response_inbox) {
+                requester_tx.send(msg).await.unwrap_or_else(|err| {
+                    warn!("Could not write response to pending request via mapping channel. Skipping! Err: {}", err);
+                });
+            }
+        }
+
+        // At this point we are either disconnecting or we're in some
+        // strange state where the subscription's rx has been closed.
+        let mut client = wrapped_client.lock().await;
+        client.request_inbox_mapping.clear();
+        client.request_wildcard_subscription = None;
+    }
+
     async fn request(
         wrapped_client: Arc<Mutex<Self>>,
         subject: &Subject,
         payload: &[u8],
     ) -> Result<Msg> {
         let inbox_uuid = Uuid::new_v4();
-        let reply_to = format!("{}.{}", util::INBOX_PREFIX, inbox_uuid.to_simple()).parse()?;
-        let mut rx = {
+
+        let (mut rx, reply_to) = {
             let mut client = wrapped_client.lock().await;
-            let (sid, rx) = client.subscribe(&reply_to, 1).await?;
-            client.unsubscribe_with_max_msgs(sid, 1).await?;
+            let request_inbox = inbox_uuid.to_simple();
+            let reply_to: Subject = format!(
+                "{}.{}.{}",
+                util::INBOX_PREFIX,
+                client.request_base_inbox,
+                request_inbox
+            )
+            .parse()?;
+
+            // Only subscribe to the wildcard subscription when requested once!
+            if client.request_wildcard_subscription.is_none() {
+                let reply_to =
+                    format!("{}.{}.*", util::INBOX_PREFIX, client.request_base_inbox).parse()?;
+                let (sid, rx) = client.subscribe(&reply_to, 1024).await?;
+                client.request_wildcard_subscription = Some(sid);
+
+                // Spawn the task that watches the request wildcard receiver.
+                tokio::spawn(Self::request_wildcard_handler(wrapped_client.clone(), rx));
+            }
+
+            let (tx, rx) = mpsc::channel(1);
+            client
+                .request_inbox_mapping
+                .insert(reply_to.to_string(), tx);
             client
                 .publish_with_reply(subject, &reply_to, payload)
                 .await?;
-            rx
+
+            (rx, reply_to)
         };
-        Ok(rx.next().await.ok_or(Error::NoResponse)?)
+
+        // Make sure we clean up on error (don't leave a dangling request
+        // inbox mapping reference. Adding an extra mutex here seems fine
+        // since this is the error path.
+        match rx.next().await {
+            Some(response) => Ok(response),
+            None => {
+                let mut client = wrapped_client.lock().await;
+                client
+                    .request_inbox_mapping
+                    .remove(&reply_to.to_string())
+                    .or_else(|| None);
+                Err(Error::NoResponse)
+            }
+        }
     }
 
     async fn subscribe(
@@ -876,11 +954,6 @@ impl SyncClient {
 
     async fn unsubscribe(&mut self, sid: Sid) -> Result<()> {
         self.unsubscribe_optional_max_msgs(sid, None).await
-    }
-
-    async fn unsubscribe_with_max_msgs(&mut self, sid: Sid, max_msgs: u64) -> Result<()> {
-        self.unsubscribe_optional_max_msgs(sid, Some(max_msgs))
-            .await
     }
 
     async fn unsubscribe_optional_max_msgs(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -844,6 +844,7 @@ impl SyncClient {
             if let Some(mut requester_tx) = client.request_inbox_mapping.remove(&msg.subject()) {
                 requester_tx.send(msg).await.unwrap_or_else(|err| {
                     warn!("Could not write response to pending request via mapping channel. Skipping! Err: {}", err);
+                    debug_assert!(false);
                 });
             }
         }

--- a/src/types.rs
+++ b/src/types.rs
@@ -416,7 +416,7 @@ impl fmt::Display for ProtocolError {
 /// let subject = "foo.bar.*.>".parse::<Subject>();
 /// assert!(subject.is_ok());
 /// ```
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct Subject {
     tokens: Vec<String>,
     full_wildcard: bool,

--- a/tests/request.rs
+++ b/tests/request.rs
@@ -3,32 +3,40 @@ mod common;
 use futures::stream::StreamExt;
 use rants::{Client, Subject};
 
-async fn main() {
-    let address = "127.0.0.1".parse().unwrap();
-    let client = Client::new(vec![address]);
-    client.connect_mut().await.echo(true);
-
-    let subject = "test_subject".parse::<Subject>().unwrap();
-
-    client.connect().await;
-
-    // Spawn a task to send the reply
+async fn make_subscription(client: Client, subject: &Subject) {
+    let mut subscription = client.subscribe(subject, 1).await.unwrap().1;
     let client_copy = Client::clone(&client);
-    let subject_copy = subject.clone();
     tokio::spawn(async move {
-        let client = client_copy;
-        let mut subscription = client.subscribe(&subject_copy, 1).await.unwrap().1;
         // Wait for the request
         let request = subscription.next().await.unwrap();
         let reply_to = request.reply_to().unwrap().clone();
         let request = String::from_utf8(request.into_payload()).unwrap();
         assert_eq!(&request, "the request");
         // Send the reply
+        let client = client_copy;
         client.publish(&reply_to, b"the reply").await.unwrap();
     });
+}
 
-    // Make a request
-    let reply = client.request(&subject, b"the request").await.unwrap();
+async fn main() {
+    let address = "127.0.0.1".parse().unwrap();
+    let client = Client::new(vec![address]);
+    client.connect_mut().await.echo(true);
+    client.connect().await;
+
+    // Spawn a few subscription tasks to send the reply
+    let subject1 = "test_subject1".parse::<Subject>().unwrap();
+    make_subscription(Client::clone(&client), &subject1).await;
+    let subject2 = "test_subject2".parse::<Subject>().unwrap();
+    make_subscription(Client::clone(&client), &subject2).await;
+
+    // Make a first request
+    let reply = client.request(&subject1, b"the request").await.unwrap();
+    let reply = String::from_utf8(reply.into_payload()).unwrap();
+    assert_eq!(&reply, "the reply");
+
+    // Make a second request
+    let reply = client.request(&subject2, b"the request").await.unwrap();
     let reply = String::from_utf8(reply.into_payload()).unwrap();
     assert_eq!(&reply, "the reply");
 


### PR DESCRIPTION
This implements the "Support improved request-reply implementation" item of the TODO list in the Readme.

This reduces the sub/unsub churn caused by a naive implementation of the request method. This is the method used in the official nats.go client.

When a timeout on request happens, the request method is responsible for cleaning up. The request handler will always remove the subscription handle when a message has been received.