### PR TITLE
RFC: Refactor request to support timeouts and always clean up on Drop

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1521,8 +1521,7 @@ impl Drop for Request {
 
             client
                 .request_inbox_mapping
-                .remove(&self.reply_to)
-                .or_else(|| None);
+                .remove(&self.reply_to);
         });
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -991,7 +991,7 @@ impl SyncClient {
         payload: &[u8],
         duration: Option<Duration>,
     ) -> Result<Msg> {
-        let mut request = Request::new(wrapped_client).await?;
+        let request = Request::new(wrapped_client).await?;
         request.call(subject, payload, duration).await
     }
 
@@ -1462,8 +1462,10 @@ impl Request {
         })
     }
 
+    // Call takes the ownership of the request to prevent double-requesting with
+    // the same request inbox.
     async fn call(
-        &mut self,
+        mut self,
         subject: &Subject,
         payload: &[u8],
         duration: Option<Duration>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1509,7 +1509,7 @@ impl Request {
                 // This happens automatically when a response is received.
                 self.request_inbox_mapping_was_removed = true;
                 Ok(response)
-            },
+            }
             None => Err(Error::NoResponse),
         }
     }
@@ -1529,9 +1529,7 @@ impl Drop for Request {
         futures::executor::block_on(async {
             let mut client = self.wrapped_client.lock().await;
 
-            client
-                .request_inbox_mapping
-                .remove(&self.reply_to);
+            client.request_inbox_mapping.remove(&self.reply_to);
         });
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1501,8 +1501,7 @@ impl Request {
         };
 
         // Make sure we clean up on error (don't leave a dangling request
-        // inbox mapping reference. Adding an extra mutex here seems fine
-        // since this is the error path.
+        // inbox mapping reference).
         match next_message {
             Some(response) => Ok(response),
             None => Err(Error::NoResponse),
@@ -1515,6 +1514,7 @@ impl Drop for Request {
     // from the client request inbox mapping.
     // NOTE: This is a blocking async block, but the only thing it blocks on
     // is the client's mutex, which should be fine.
+    // When/if async drop becomes available we should use that instead.
     fn drop(&mut self) {
         futures::executor::block_on(async {
             let mut client = self.wrapped_client.lock().await;


### PR DESCRIPTION
It might actually be worth splitting this PR into two.

This PR adds:
1. a new `request_with_timeout` interface that allows the caller to supply a duration. The existing `request` method will call into the new timeout method with `None` and the impl will not apply a timeout. No breaking changes.
2. a new `Request` type that holds the logic and ownership of the reply_to subscription so it can remove it from the client when the request is dropped. So whether a timeout happens, subject parsing error, or the caller gives up, ... doesn't matter, the reply_to will always be removed from the inbox mapping.

The `Request` type needs some improvement, but it does solve https://github.com/davidMcneil/rants/issues/4. I don't like the way drop is implemented, but it does seem reasonable. I'm not sure how much slower it will be since the lock could be expensive if the client is busy with a line of lock acquirers. I also think it might be worth setting a flag on error so we only attempt to cleanup if we absolutely need to.

I also don't like how the Request type is very involved with spawning the clients request handler. Not pretty at all. Still, I was hoping for some feedback :+1: / :-1: on the approach, and if :-1: , what I should do differently.

