### PR TITLE
Remove uses of pin_project::project attribute

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ futures = "0.3.1"
 log = "0.4.8"
 nom = "5.0.1"
 owning_ref = "0.4.0"
-pin-project = "0.4.6"
+pin-project = "0.4.17"
 rand = "0.7.2"
 serde = { version = "1.0.101", features = ["derive"] }
 serde_json = "1.0.40"


### PR DESCRIPTION
pin-project will deprecate the project attribute due to some unfixable
limitations.

Refs: https://github.com/taiki-e/pin-project/issues/225

*Although the deprecation of the project attribute has not been released yet, this PR is submitted in advance to avoid the CI from being broken by deprecated warnings.*
